### PR TITLE
Omit early commits

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,22 @@ data from all repositories of the project. Like `init-project`,
 `--earliest-commit-date` options with the same semantics for
 the added repository.
 
+## Database Migrations
+
+If you update Git Hammer, it is possible that the database
+schema is updated in the new version. This means that you will
+need to migrate any existing databases to the latest version.
+Migration is performed by running
+```bash
+HAMMER_DATABASE_URL=<URL of database to migrate> alembic upgrade head
+```
+(If you haven't installed Git Hammer with `pip`, run this command
+in the project directory and add `PYTHONPATH=.` at the beginning.)
+
+It is safe to run this even if the database schema has not changed
+in the update, so there is no need to try and figure that out before
+running the migration.
+
 ## License
 
 Git Hammer is licensed under the Apache Software License,

--- a/README.md
+++ b/README.md
@@ -91,6 +91,17 @@ python -m githammer update-project baffle
 This will process all the new commits that were not yet seen
 into the database.
 
+If the repository is very old, with much history, you might
+not be interested in capturing all of it. `init-project`
+has the option `--earliest-commit-date` that provides a date
+so that commits prior to that date are not included. This
+would be used like
+```bash
+python -m githammer init-project baffle ~/projects/baffle --earliest-commit-date 2018-01-01
+```
+It is currently not possible to later add commits that were
+excluded by date when the repository was added.
+
 ## Showing Statistics
 
 After the project has been initialized and the repository added,
@@ -225,8 +236,9 @@ python -m githammer add-repository baffle ~/projects/baffle-common
 This will process the new repository, adding it to the project
 database. After this, any summary information will include
 data from all repositories of the project. Like `init-project`,
-`add-repository` also accepts the `--configuration` option to
-specify the configuration file for the new repository.
+`add-repository` also accepts the `--configuration` and
+`--earliest-commit-date` options with the same semantics for
+the added repository.
 
 ## License
 

--- a/alembic/versions/d95efca6f334_add_start_time_to_repository_object.py
+++ b/alembic/versions/d95efca6f334_add_start_time_to_repository_object.py
@@ -1,0 +1,26 @@
+"""Add start time to Repository object
+
+Revision ID: d95efca6f334
+Revises: 
+Create Date: 2020-01-06 16:24:08.055349
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'd95efca6f334'
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('repositories', sa.Column('start_time', sa.DateTime(), nullable=True))
+    op.add_column('repositories', sa.Column('start_time_utc_offset', sa.Integer(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('repositories', 'start_time_utc_offset')
+    op.drop_column('repositories', 'start_time')

--- a/githammer/countdict.py
+++ b/githammer/countdict.py
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-def _normalize_count_dict(count_dict):
+
+def normalize_count_dict(count_dict):
     return {key: value for key, value in count_dict.items() if value != 0}
 
 
@@ -20,11 +21,11 @@ def subtract_count_dict(base_dict, dict_to_subtract):
     result_dict = base_dict.copy()
     for key, value in dict_to_subtract.items():
         result_dict[key] = result_dict.get(key, 0) - value
-    return _normalize_count_dict(result_dict)
+    return normalize_count_dict(result_dict)
 
 
 def add_count_dict(base_dict, dict_to_add):
     result_dict = base_dict.copy()
     for key, value in dict_to_add.items():
         result_dict[key] = result_dict.get(key, 0) + value
-    return _normalize_count_dict(result_dict)
+    return normalize_count_dict(result_dict)

--- a/githammer/hammer.py
+++ b/githammer/hammer.py
@@ -164,6 +164,7 @@ class Hammer:
             self._process_lines_into_line_counts(repository, commit, path, lines, line_counts, test_counts)
 
     def _make_full_commit_stats(self, repository, commit, need_full_blame=False):
+        stats_start_time = datetime.datetime.now()
         line_counts = {}
         test_counts = {}
         for git_object in commit.tree.traverse(visit_once=True):
@@ -176,6 +177,8 @@ class Hammer:
             else:
                 lines = [line.decode('utf-8', 'ignore') for line in io.BytesIO(git_object.data_stream.read()).readlines()]
                 self._process_lines_into_line_counts(repository, commit, git_object.path, lines, line_counts, test_counts)
+        print('Commit {} stats time: {}'.format(commit.hexsha,
+                                                datetime.datetime.now() - stats_start_time))
         return normalize_count_dict(line_counts), normalize_count_dict(test_counts)
 
     def _make_diffed_commit_stats(self, repository, commit, previous_commit, previous_commit_line_counts,
@@ -289,10 +292,7 @@ class Hammer:
                     line_counts, test_counts = self._make_full_commit_stats(repository, commit,
                                                                             need_full_blame=need_full_blame)
             else:
-                full_stats_start_time = datetime.datetime.now()
                 line_counts, test_counts = self._make_full_commit_stats(repository, commit)
-                print('Commit {} stats time: {}'.format(commit.hexsha,
-                                                        datetime.datetime.now() - full_stats_start_time))
             self._add_commit_line_counts(commit, line_counts, test_counts, session)
             repository.head_commit_id = commit.hexsha
             commit_count += 1

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -6,3 +6,4 @@ from .test_multiple_projects import HammerMultipleProjectsTest
 from .test_update import HammerUpdateTest
 from .test_shallow_repository import HammerShallowTest
 from .test_multiple_repositories import HammerMultipleRepositoriesTest
+from .test_limited_repository import HammerLimitedTest

--- a/tests/data/repository/info/refs
+++ b/tests/data/repository/info/refs
@@ -1,3 +1,4 @@
+c80ee8a32baaee8df8133b8afca26d63d857684e	refs/heads/december
 10247c3a05e4bd35d827ed527a0aed39990338ea	refs/heads/feature
 74e48c8686b26dc644951b55717e8828eb704587	refs/heads/master
 c153f2881f0f0025a9ff5754e74111333ce859cd	refs/heads/old-state

--- a/tests/data/repository/objects/9f/5ed1b1c43e211a30e6b9cc60ce26540ab9df70
+++ b/tests/data/repository/objects/9f/5ed1b1c43e211a30e6b9cc60ce26540ab9df70
@@ -1,2 +1,0 @@
-xuŽÁjÃ0D{ÖWì=P´²%[JrM¿b´Z5Žc;¨2ôóëC¯Ìá1²-ËÔÈ¹ðÖª*iŠ!$”Ôç~ôª
-Rò9°”hÇ"Ñ&6/T]yöG_í¼g:‘¼d¸dsìSgÂ`o÷­ÒõtÆE°¼žú.ÛòAì‡p¤wŽN–­5Çz<kZéÌóFŸX¿ð}G}ìt~ÌX/eo{ä?ƒ¹æ¬™2¨LO5¿çGÞ

--- a/tests/data/repository/packed-refs
+++ b/tests/data/repository/packed-refs
@@ -1,4 +1,5 @@
 # pack-refs with: peeled fully-peeled sorted 
+c80ee8a32baaee8df8133b8afca26d63d857684e refs/heads/december
 10247c3a05e4bd35d827ed527a0aed39990338ea refs/heads/feature
 74e48c8686b26dc644951b55717e8828eb704587 refs/heads/master
 c153f2881f0f0025a9ff5754e74111333ce859cd refs/heads/old-state

--- a/tests/hammer_test.py
+++ b/tests/hammer_test.py
@@ -17,8 +17,10 @@ class HammerTest(unittest.TestCase):
             hammer = self.hammer
         return next(c for c in hammer.iter_individual_commits() if c.hexsha == hexsha)
 
-    def _make_hammer(self, project_name):
-        return Hammer(project_name, self.database_url)
+    def _make_hammer(self, project_name, database_url=None):
+        if not database_url:
+            database_url = self.database_url
+        return Hammer(project_name, database_url)
 
     def setUp(self):
         print()

--- a/tests/test_limited_repository.py
+++ b/tests/test_limited_repository.py
@@ -1,15 +1,18 @@
 import os
 import datetime
 
+import git
+
 from .hammer_test import HammerTest
 
 
 class HammerLimitedTest(HammerTest):
     def setUp(self):
         super().setUp()
+        self.start_date = datetime.datetime(2018, 1, 1, 0, 0, 0, tzinfo=datetime.timezone.utc)
         self.hammer.add_repository(os.path.join(self.current_directory, 'data', 'repository'),
                                    os.path.join(self.current_directory, 'data', 'repo-config.json'),
-                                   earliest_date=datetime.datetime(2018, 1, 1, 0, 0, 0, tzinfo=datetime.timezone.utc))
+                                   earliest_date=self.start_date)
 
     def test_limiting_by_date_includes_only_commits_after(self):
         commits = list(self.hammer.iter_individual_commits())
@@ -22,3 +25,25 @@ class HammerLimitedTest(HammerTest):
             authors['Author B']: 9,
             authors['Author C']: 2
         })
+
+    def test_updating_project_does_not_add_new_commits(self):
+        self.hammer.update_data()
+        commits = list(self.hammer.iter_individual_commits())
+        self.assertEqual(len(commits), 3)
+
+    def test_updating_brings_in_later_commits_but_not_excluded_ones(self):
+        other_hammer = self._make_hammer('otherTest',
+                                         database_url='sqlite:///' + self.working_directory.name + '/other.sqlite')
+        git_repository = git.Repo.clone_from(os.path.join(self.current_directory, 'data', 'repository'),
+                                             os.path.join(self.working_directory.name, 'worktree'),
+                                             branch='december', single_branch=True)
+        other_hammer.add_repository(os.path.join(self.working_directory.name, 'worktree'),
+                                    earliest_date=self.start_date)
+        initial_commits = list(other_hammer.iter_individual_commits())
+        self.assertEqual(len(initial_commits), 1)
+        git_repository.remote().fetch('+refs/heads/master:refs/remotes/origin/master')
+        git_repository.create_head('master', git_repository.remote().refs.master)
+        git_repository.heads.master.checkout()
+        other_hammer.update_data()
+        updated_commits = list(other_hammer.iter_individual_commits())
+        self.assertEqual(len(updated_commits), 3)

--- a/tests/test_limited_repository.py
+++ b/tests/test_limited_repository.py
@@ -1,0 +1,16 @@
+import os
+import datetime
+
+from .hammer_test import HammerTest
+
+
+class HammerLimitedTest(HammerTest):
+    def setUp(self):
+        super().setUp()
+        self.hammer.add_repository(os.path.join(self.current_directory, 'data', 'repository'),
+                                   os.path.join(self.current_directory, 'data', 'repo-config.json'),
+                                   earliest_date=datetime.datetime(2018, 1, 1, 0, 0, 0, tzinfo=datetime.timezone.utc))
+
+    def test_limiting_by_date_includes_only_commits_after(self):
+        commits = list(self.hammer.iter_individual_commits())
+        self.assertEqual(len(commits), 3)

--- a/tests/test_limited_repository.py
+++ b/tests/test_limited_repository.py
@@ -14,3 +14,11 @@ class HammerLimitedTest(HammerTest):
     def test_limiting_by_date_includes_only_commits_after(self):
         commits = list(self.hammer.iter_individual_commits())
         self.assertEqual(len(commits), 3)
+
+    def test_line_counts_are_correct_in_date_limited_repository(self):
+        authors = {author.name: author for author in self.hammer.iter_authors()}
+        self.assertEqual(self.hammer.head_commit().line_counts, {
+            authors['Author A']: 7,
+            authors['Author B']: 9,
+            authors['Author C']: 2
+        })

--- a/tests/test_single_repository.py
+++ b/tests/test_single_repository.py
@@ -47,14 +47,9 @@ class HammerRepositoryTest(HammerTest):
         self.assertEqual(self.hammer.head_commit().test_counts, {author: 1})
 
     def test_line_counts_are_correct_after_merge(self):
-        initial_commit = self._fetch_commit(HammerRepositoryTest._main_repo_initial_commit_hexsha)
-        second_commit = self._fetch_commit(HammerRepositoryTest._main_repo_second_commit_hexsha)
-        test_commit = self._fetch_commit(HammerRepositoryTest._main_repo_test_commit_hexsha)
-        author_a = initial_commit.author
-        author_b = second_commit.author
-        author_c = test_commit.author
+        authors = {author.name: author for author in self.hammer.iter_authors()}
         self.assertEqual(self.hammer.head_commit().line_counts, {
-            author_a: 7,
-            author_b: 9,
-            author_c: 2
+            authors['Author A']: 7,
+            authors['Author B']: 9,
+            authors['Author C']: 2
         })


### PR DESCRIPTION
Add a way to limit commits processed from a repository by date so that commits earlier than a specified date won't be included. Currently no way to reverse this setting for an added repository.

This closes #5 