### PR TITLE
Fix submodule handling in the initial commit

### DIFF
--- a/githammer/hammer.py
+++ b/githammer/hammer.py
@@ -167,7 +167,7 @@ class Hammer:
         stats_start_time = datetime.datetime.now()
         line_counts = {}
         test_counts = {}
-        for git_object in commit.tree.traverse(visit_once=True):
+        for git_object in commit.tree.traverse(prune=lambda i, d: i is git.Submodule):
             if git_object.type != 'blob':
                 continue
             if not repository.configuration.is_source_file(git_object.path):
@@ -175,8 +175,10 @@ class Hammer:
             if need_full_blame:
                 self._blame_blob_into_line_counts(repository, commit, git_object.path, line_counts, test_counts)
             else:
-                lines = [line.decode('utf-8', 'ignore') for line in io.BytesIO(git_object.data_stream.read()).readlines()]
-                self._process_lines_into_line_counts(repository, commit, git_object.path, lines, line_counts, test_counts)
+                lines = [line.decode('utf-8', 'ignore') for line in
+                         io.BytesIO(git_object.data_stream.read()).readlines()]
+                self._process_lines_into_line_counts(repository, commit, git_object.path, lines, line_counts,
+                                                     test_counts)
         print('Commit {} stats time: {}'.format(commit.hexsha,
                                                 datetime.datetime.now() - stats_start_time))
         return normalize_count_dict(line_counts), normalize_count_dict(test_counts)

--- a/tests/test_submodule.py
+++ b/tests/test_submodule.py
@@ -16,6 +16,16 @@ class HammerSubmoduleTest(HammerTest):
         author = git.Actor('Author A', 'a@example.com')
         repository.index.commit('Add subrepo', author=author)
 
-    def test_repository_with_submodule_is_understood(self):
+    def test_repository_with_added_submodule_is_understood(self):
         self.hammer.add_repository(os.path.join(self.working_directory.name, 'worktree'))
         self.assertIsNotNone(self.hammer.head_commit())
+
+    def test_submodule_in_initial_commit_is_understood(self):
+        submodule_repository = git.Repo.init(os.path.join(self.working_directory.name, 'initial_submodule'))
+        git.Submodule.add(submodule_repository, 'subrepo', 'subrepo',
+                          os.path.join(self.current_directory, 'data', 'subrepository'))
+        author = git.Actor('Author B', 'b@example.com')
+        submodule_repository.index.commit('Initial commit', author=author)
+        self.hammer.add_repository(os.path.join(self.working_directory.name, 'initial_submodule'))
+        commit = next(self.hammer.iter_individual_commits())
+        self.assertEqual(commit.line_counts, {commit.author: 3})


### PR DESCRIPTION
When handling the initial commit, Git Hammer uses the traverse
function of the tree object, passing it the visit_once parameter
to make sure each file is processed only once. Unfortunately this
breaks when the tree contains submodules, since the visited check
in traverse raises an exception because of a GitPython issue
(https://github.com/gitpython-developers/GitPython/issues/597).

Remove the visit_once parameter from the traverse call. Since
it's the default for a tree object, it should be safe. Also add
pruning of submodules and a test to verify that submodules in the
initial commit are correctly ignored.

This fixes #20 